### PR TITLE
Update for Python 3

### DIFF
--- a/yaml2toml.py
+++ b/yaml2toml.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from jinja2 import Template
-from yaml import load
+from yaml import safe_load
 import argparse
 import sys
 
@@ -37,7 +37,7 @@ def main():
     args.template_fh.close()
 
     # Read the YAML file
-    yaml_data = load(args.yaml_fh)
+    yaml_data = safe_load(args.yaml_fh)
     args.yaml_fh.close()
 
     # Create jinja template object
@@ -46,7 +46,7 @@ def main():
     toml_output = t.module.yaml2toml(yaml_data).encode('utf8')
 
     # Print the result
-    sys.stdout.write(toml_output)
+    sys.stdout.buffer.write(toml_output)
 
 
 if __name__ == '__main__':

--- a/yaml2toml_macro.j2
+++ b/yaml2toml_macro.j2
@@ -8,7 +8,7 @@
     {#- The item is a dict #}
 
     {#- First process all strings, numbers and lists #}
-    {%- for key, value in item.iteritems() | sort -%}
+    {%- for key, value in item.items() | sort -%}
       {%- if value is string or
           value is number or
           (
@@ -28,7 +28,7 @@
     {%- endfor %}
 
     {#- Then process all data structures #}
-    {%- for key, value in item.iteritems() | sort %}
+    {%- for key, value in item.items() | sort %}
       {%- if value is not string and
           value is not number and
           (


### PR DESCRIPTION
```
*  Update for Python 3
   
   Run yaml2toml.py in Python 3. Use safe_load() rather than load() for
   loading YAML. Use items() instead of iteritems() for iteration.
   
   Output the result using sys.stdout.buffer.write() to force UTF-8
   encoding.
   
   Signed-off-by: Pavel Roskin <plroskin@gmail.com>
```